### PR TITLE
docs: document env setup and variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains the Next.js based front-end for the TSWoW project. It r
    ```bash
    npm install
    ```
-2. Ensure the backend service is running locally at `http://127.0.0.1:3001` or set the environment variables listed below to point to your backend.
+2. Copy `.env.local.example` to `.env.local` and adjust the URLs if your backend is not running at `http://127.0.0.1:3001`.
 3. Start the development server:
    ```bash
    npm run dev
@@ -22,8 +22,12 @@ This repository contains the Next.js based front-end for the TSWoW project. It r
 
 ## Environment Variables
 
+Copy `.env.local.example` to `.env.local` to provide the following variables:
+
+- `BACKEND_URL_REGISTER` – URL to the backend register endpoint (default: `http://127.0.0.1:3001/auth/register`).
 - `BACKEND_URL_LOGIN` – URL to the backend login endpoint (default: `http://127.0.0.1:3001/auth/login`).
 - `BACKEND_URL_ME` – URL to the backend `me` endpoint (default: `http://127.0.0.1:3001/auth/me`).
+- `BACKEND_URL_REALM` – URL to the backend realm info endpoint (default: `http://127.0.0.1:3001/realm/info`).
 
 ## Available Scripts
 


### PR DESCRIPTION
## Summary
- instruct developers to copy `.env.local.example` when configuring backend URLs
- document register and realm backend endpoints alongside existing login and me variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1f3d0df883288346442dddb103ee